### PR TITLE
Make compatible with Python 3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6 || ^3.7"
-aiohttp = "^3.5"
+python = "^3.5 || ^3.6 || ^3.7"
+aiohttp = "3.0.0b0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.5 || ^3.6 || ^3.7"
-aiohttp = "3.0.0b0"
+aiohttp = "^3.5 || ^3.0.0b0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/wuy.py
+++ b/wuy.py
@@ -744,7 +744,7 @@ class Base:
         if application is None:
 
             application = web.Application()
-            application.add_routes(
+            application.router.add_routes(
                 [
                     web.get("/_ws_{page}", wshandle),
                     web.get("/{path:.*}wuy.js", handleJs),

--- a/wuy.py
+++ b/wuy.py
@@ -743,16 +743,20 @@ class Base:
 
         if application is None:
 
+            routes = [
+                        web.get("/_ws_{page}", wshandle),
+                        web.get("/{path:.*}wuy.js", handleJs),
+                        web.get("/", handleWeb),
+                        web.route("*", "/_/{url:.+}", handleProxy),
+                        web.route("*", "/{path:.+}", handleWeb),
+                     ]
+
             application = web.Application()
-            application.router.add_routes(
-                [
-                    web.get("/_ws_{page}", wshandle),
-                    web.get("/{path:.*}wuy.js", handleJs),
-                    web.get("/", handleWeb),
-                    web.route("*", "/_/{url:.+}", handleProxy),
-                    web.route("*", "/{path:.+}", handleWeb),
-                ]
-            )
+            try:
+                application.add_routes(routes)
+            except AttributeError:
+                application.router.add_routes(routes)  # Py3.5 + aiohttp3.0b
+
             application.on_shutdown.append(on_shutdown)
             try:
                 if (


### PR DESCRIPTION
This has allowed for Wuy to work again with Python3.5.

It may not be fashionable but it still runs in a lot of production servers (Debian 9).

Also, incidentally this allows Wuy to run in Glitch.com:
https://glitch.com/edit/#!/heroe

:-)